### PR TITLE
Add caching for Bitcoin Core and organize test structure

### DIFF
--- a/.github/setup.sh
+++ b/.github/setup.sh
@@ -1,5 +1,3 @@
-wget https://bitcoincore.org/bin/bitcoin-core-28.0/bitcoin-28.0-x86_64-linux-gnu.tar.gz
-tar -xzvf bitcoin-28.0-x86_64-linux-gnu.tar.gz
 ln -s $PWD/bitcoin-28.0/bin/* /usr/local/bin/
 mkdir -p ~/.bitcoin
 

--- a/.github/tests/chain.test.sh
+++ b/.github/tests/chain.test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Running Chain Test..."
+chmod +x submission/02.sh
+CHAIN=$(submission/02.sh)
+echo "Bitcoin chain: $CHAIN"
+
+if [[ "$CHAIN" == "regtest" ]]; then
+  echo "✅ Chain verification passed!"
+  exit 0
+else
+  echo "❌ Chain verification failed!"
+  exit 1
+fi 

--- a/.github/tests/version.test.sh
+++ b/.github/tests/version.test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Running Bitcoin Version Test..."
+BITCOIN_VERSION=$(submission/01.sh)
+echo "Bitcoin CLI Version: $BITCOIN_VERSION"
+
+if [[ $BITCOIN_VERSION == *"28"* ]]; then
+  echo "✅ Success: Bitcoin CLI version"
+  exit 0
+else
+  echo "❌ Error: Bitcoin CLI version failed"
+  exit 1
+fi 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,26 +46,8 @@ jobs:
           done
 
       - name: Verify Bitcoin CLI version
-        run: |
-          BITCOIN_VERSION=$(submission/01.sh)
-          echo "Bitcoin CLI Version: $BITCOIN_VERSION"
-
-          if [[ $BITCOIN_VERSION == *"28"* ]]; then
-            echo "Success: Bitcoin CLI version"
-          else
-            echo "Error: Bitcoin CLI version failed"
-            exit 1
-          fi
+        run: bash .github/tests/version.test.sh
 
       - name: Verify Bitcoin chain
-        run: |
-            chmod +x submission/02.sh
-            CHAIN=$(submission/02.sh)
-            echo "Bitcoin chain: $CHAIN"
-            if [[ "$CHAIN" == "regtest" ]]; then
-              echo "Chain verification passed!"
-            else
-              echo "Chain verification failed!"
-              exit 1
-            fi
+        run: bash .github/tests/chain.test.sh
             

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4  # Check out the repository code
 
-      - name: Run Bitcoin Core setup script
+      - name: Cache Bitcoin Core
+        id: cache-bitcoin
+        uses: actions/cache@v3
+        with:
+          path: |
+            bitcoin-28.0
+            bitcoin-28.0-x86_64-linux-gnu.tar.gz
+          key: bitcoin-core-28.0
+          
+      - name: Setup Bitcoin Core
         run: |
-          chmod +x .github/setup.sh
-          .github/setup.sh
+          if [ "${{ steps.cache-bitcoin.outputs.cache-hit }}" != 'true' ]; then
+            wget https://bitcoincore.org/bin/bitcoin-core-28.0/bitcoin-28.0-x86_64-linux-gnu.tar.gz
+            tar -xzvf bitcoin-28.0-x86_64-linux-gnu.tar.gz
+          fi
+          sudo bash .github/setup.sh
 
       - name: Start bitcoind in regtest mode
         run: |


### PR DESCRIPTION
This PR closes #1 and #2 that I opened.

Changes: 
- Implements caching for Bitcoin Core downloads in GitHub workflow to reduce redundant downloads. The workflow now checks for cached binaries before performing new downloads.
- Our GitHub actions workflow currently contains all tests within the `main.yml`. We restructure this by moving tests into individual files within a dedicated `.github/tests` directory, which makes it easy to extend with new tests.

I made a separate commit for each of these changes to make the review process easier